### PR TITLE
Master

### DIFF
--- a/Messenger/Bots.Messenger/SendAPI/Recipient.cs
+++ b/Messenger/Bots.Messenger/SendAPI/Recipient.cs
@@ -7,7 +7,7 @@ namespace Messenger.Bot.SendAPI
         [JsonProperty("id")]
         public string Id { get; set; }
 
-        [JsonProperty("phone_number")]
+        [JsonProperty("phone_number", NullValueHandling = NullValueHandling.Ignore)]
         public string PhoneNumber;
 
         [JsonProperty("user_ref")]


### PR DESCRIPTION
fix when sendmessage set phoneNumber to null also require facebook permission of pages_messaging_phone_number